### PR TITLE
Switch to Docker Hub

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -1,7 +1,7 @@
 name: Build branch
 on:
   push:
-    branches: ["!master"]
+    branches-ignore: [master]
 jobs:
   build:
     name: Build

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -11,9 +11,9 @@ jobs:
         uses: actions/checkout@v1
       - name: Docker login
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: docker login docker.pkg.github.com -u arikkfir -p "${GITHUB_TOKEN}"
+          DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        run: docker login --username arikkfir -p "${DOCKERHUB_ACCESS_TOKEN}"
       - name: Build ref mage
-        run: docker build --tag=docker.pkg.github.com/${GITHUB_REPOSITORY}/neo4j:${GITHUB_SHA::7} .
+        run: docker build --tag=${GITHUB_REPOSITORY}:${GITHUB_SHA::7} .
       - name: Push ref image
-        run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/neo4j:${GITHUB_SHA::7}
+        run: docker push ${GITHUB_REPOSITORY}:${GITHUB_SHA::7}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,13 +11,13 @@ jobs:
         uses: actions/checkout@v1
       - name: Docker login
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: docker login docker.pkg.github.com -u arikkfir -p "${GITHUB_TOKEN}"
+          DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        run: docker login --username arikkfir -p "${DOCKERHUB_ACCESS_TOKEN}"
       - name: Build image
-        run: docker build --tag=docker.pkg.github.com/${GITHUB_REPOSITORY}/neo4j:${GITHUB_SHA::7} .
+        run: docker build --tag=${GITHUB_REPOSITORY}:${GITHUB_SHA::7} .
       - name: Tag ref image as latest
-        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/neo4j:${GITHUB_SHA::7} docker.pkg.github.com/${GITHUB_REPOSITORY}/neo4j:latest
+        run: docker tag ${GITHUB_REPOSITORY}:${GITHUB_SHA::7} ${GITHUB_REPOSITORY}:latest
       - name: Push ref image
-        run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/neo4j:${GITHUB_SHA::7}
+        run: docker push ${GITHUB_REPOSITORY}:${GITHUB_SHA::7}
       - name: Push latest image
-        run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/neo4j:latest
+        run: docker push ${GITHUB_REPOSITORY}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ jobs:
         uses: actions/checkout@v1
       - name: Docker login
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: docker login docker.pkg.github.com -u arikkfir -p "${GITHUB_TOKEN}"
+          DOCKERHUB_ACCESS_TOKEN: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        run: docker login --username arikkfir -p "${DOCKERHUB_ACCESS_TOKEN}"
       - name: Pull ref image
-        run: docker pull docker.pkg.github.com/${GITHUB_REPOSITORY}/neo4j:${GITHUB_SHA::7}
+        run: docker pull ${GITHUB_REPOSITORY}:${GITHUB_SHA::7}
       - name: Tag ref image as release image
-        run: docker tag docker.pkg.github.com/${GITHUB_REPOSITORY}/neo4j:${GITHUB_SHA::7} docker.pkg.github.com/${GITHUB_REPOSITORY}/neo4j:$(cut -d'/' -f3 <<<${GITHUB_REF})
+        run: docker tag ${GITHUB_REPOSITORY}:${GITHUB_SHA::7} ${GITHUB_REPOSITORY}:$(cut -d'/' -f3 <<<${GITHUB_REF})
       - name: Push Image
-        run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/neo4j:$(cut -d'/' -f3 <<<${GITHUB_REF})
+        run: docker push ${GITHUB_REPOSITORY}:$(cut -d'/' -f3 <<<${GITHUB_REF})


### PR DESCRIPTION
We cannot use GitHub Packages as it is a private Docker registry - and those
cannot be used by GitHub Actions for job containers or job services.